### PR TITLE
Variable replacement and appropriate branch root path

### DIFF
--- a/BranchPresets/AddFromBranchPreset.cs
+++ b/BranchPresets/AddFromBranchPreset.cs
@@ -66,8 +66,10 @@ namespace BranchPresets
 
 				var relativeRenderingPath = renderingTargetItem.Paths.FullPath.Substring(branchBasePath.Length).TrimStart('/');
 				relativeRenderingPath = relativeRenderingPath.Substring(relativeRenderingPath.IndexOf('/')); // we need to skip the "/$name" at the root of the branch children
-
-				var newTargetPath = item.Paths.FullPath + relativeRenderingPath;
+                                //Using variable replacement in case subpath includes variables/tokens
+				var fixedRelativeRenderingPath = new Sitecore.Data.MasterVariablesReplacer().Replace(relativeRenderingPath, item.Database.GetItem(branchRoot));
+                                //Use the passed branch root to determine new target path
+                                var newTargetPath = branchRoot + fixedRelativeRenderingPath;
 
 				var newTargetItem = item.Database.GetItem(newTargetPath);
 


### PR DESCRIPTION
There appears to be a bug for the nested items, where the 'branchRoot' path was supposed to be used to determine the relative path (appears to be why it was added).  I also added variable replacement, as we have subpages that use the parents name in the URL.